### PR TITLE
Starts off the iOS portion of fhirstarters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,69 @@ ModelManifest.xml
 # Maven
 target/
 
+### Xcode
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+*.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ios/FHIRPatients"]
+	path = ios/FHIRPatients
+	url = https://github.com/ryanbaldwin/FHIRPatients

--- a/README.md
+++ b/README.md
@@ -5,4 +5,5 @@ This repository contains samples to get you started at playing with FHIR!
 * [Browser/Postman Tutorial](./postman/): First introduction, requires no coding
 * [Java/HAPI](./java/): Sample client and server projects in Java
 * [.NET](./dotnet/): Sample project in .NET/C#
+* [iOS](./ios/): Sample client project in iOS/Swift 4
 * [Beginner's Track](./BeginnersTrack.md): Exercises used for the hands-on track during the FHIR Developer Days


### PR DESCRIPTION
This is a relatively simple PR which
- creates the `ios` directory
- creates a git submodule to [https://github.com/ryanbaldwin/FHIRPatients](https://github.com/ryanbaldwin/FHIRPatients) in `ios/FHIRPatients`
- adds a bunch of Xcode specific entries to the `.gitignore`